### PR TITLE
Add customer and admin portals for kosher chicken orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # pedidos-frigorifico-v1.8
-una pagina web para un frigorifico de pollos en el que haya un enlace para los administradores y uno para los clientes con distintas funciones
+
+Sitio web estático para gestionar pedidos mayoristas de cajones de pollo kosher. Incluye un panel de clientes para registrar pedidos y un panel exclusivo para administradores donde se puede gestionar stock, precios, historial de compras, entregas y accesos de administradores.
+
+## Cómo usar
+
+1. Abra `index.html` en su navegador para acceder al sitio.
+2. Desde la portada podrá elegir entre el panel de **clientes** o el de **administradores**.
+3. Los clientes completan el formulario con el nombre del local, la dirección, el tipo de cajón y la cantidad deseada. El pedido queda guardado para ser administrado posteriormente.
+4. Los administradores ingresan con usuario y contraseña preconfigurados en el código (`script.js`). Cada administrador debe indicar su nombre visible, que quedará registrado en el historial exclusivo del panel.
+5. Una vez dentro del panel se puede:
+   - Actualizar el stock disponible de cada tipo de cajón.
+   - Definir o modificar los precios mayoristas.
+   - Revisar el historial completo de pedidos y marcar las entregas, dejando constancia de fecha, cantidad entregada y responsable.
+   - Consultar el historial de accesos de administradores.
+
+Los datos se almacenan en el navegador mediante `localStorage`, por lo que se conservan mientras no se borre el almacenamiento local del navegador.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frigorífico Kosher - Gestión de Cajones</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Frigorífico Kosher</h1>
+        <p class="tagline">Pedidos mayoristas de cajones de pollo kosher - no se realizan pedidos particulares.</p>
+        <nav>
+            <a href="#cliente" id="cliente-link">Ingreso de clientes</a>
+            <a href="#admin" id="admin-link">Ingreso de administradores</a>
+        </nav>
+    </header>
+
+    <main>
+        <section id="cliente" class="panel">
+            <h2>Pedidos para clientes</h2>
+            <p>Complete los datos de su comercio y seleccione el cajón deseado.</p>
+            <form id="cliente-form">
+                <label for="cliente-nombre">Nombre del local</label>
+                <input type="text" id="cliente-nombre" required>
+
+                <label for="cliente-direccion">Dirección</label>
+                <input type="text" id="cliente-direccion" required>
+
+                <label for="cliente-cajon">Tipo de cajón</label>
+                <select id="cliente-cajon" required>
+                    <!-- opciones generadas dinámicamente -->
+                </select>
+
+                <label for="cliente-cantidad">Cantidad de cajones</label>
+                <input type="number" id="cliente-cantidad" min="1" step="1" required>
+
+                <button type="submit">Enviar pedido</button>
+            </form>
+            <div id="cliente-mensaje" role="status" aria-live="polite"></div>
+        </section>
+
+        <section id="admin" class="panel">
+            <h2>Acceso para administradores</h2>
+            <form id="admin-login-form">
+                <label for="admin-alias">Nombre a mostrar</label>
+                <input type="text" id="admin-alias" required>
+
+                <label for="admin-usuario">Usuario</label>
+                <input type="text" id="admin-usuario" required>
+
+                <label for="admin-password">Contraseña</label>
+                <input type="password" id="admin-password" required>
+
+                <button type="submit">Ingresar</button>
+            </form>
+            <div id="admin-login-error" role="alert"></div>
+
+            <section id="admin-panel" hidden>
+                <div class="admin-header">
+                    <h3>Panel de administración</h3>
+                    <button id="admin-logout" class="secondary">Cerrar sesión</button>
+                </div>
+                <p class="bienvenida"></p>
+
+                <div class="admin-grid">
+                    <article>
+                        <h4>Stock de cajones</h4>
+                        <table id="tabla-stock">
+                            <thead>
+                                <tr>
+                                    <th>Cajón</th>
+                                    <th>Stock actual</th>
+                                    <th>Actualizar</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </article>
+
+                    <article>
+                        <h4>Precios mayoristas</h4>
+                        <table id="tabla-precios">
+                            <thead>
+                                <tr>
+                                    <th>Cajón</th>
+                                    <th>Precio actual</th>
+                                    <th>Actualizar</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </article>
+
+                    <article class="historial">
+                        <h4>Historial de pedidos</h4>
+                        <table id="tabla-pedidos">
+                            <thead>
+                                <tr>
+                                    <th>Fecha</th>
+                                    <th>Cliente</th>
+                                    <th>Cajón</th>
+                                    <th>Cantidad</th>
+                                    <th>Estado</th>
+                                    <th>Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </article>
+
+                    <article class="historial">
+                        <h4>Historial de entregas</h4>
+                        <ul id="lista-entregas"></ul>
+                    </article>
+
+                    <article class="historial">
+                        <h4>Historial de accesos administrativos</h4>
+                        <ul id="lista-logins"></ul>
+                    </article>
+                </div>
+            </section>
+        </section>
+    </main>
+
+    <footer>
+        <small>&copy; <span id="anio-actual"></span> Frigorífico Kosher. Todos los derechos reservados.</small>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,426 @@
+const CAJONES = [
+    { id: 'cajon-x', nombre: 'Cajón X' },
+    { id: '6-cabezas', nombre: 'Cajón de 6 cabezas' },
+    { id: '7-cabezas', nombre: 'Cajón de 7 cabezas' },
+    { id: '8-cabezas', nombre: 'Cajón de 8 cabezas' },
+    { id: '9-cabezas', nombre: 'Cajón de 9 cabezas' },
+    { id: '10-cabezas', nombre: 'Cajón de 10 cabezas' }
+];
+
+const ADMINISTRADORES = [
+    { usuario: 'central', password: 'kosher2024' },
+    { usuario: 'logistica', password: 'frigo2024' }
+];
+
+let adminActivo = null;
+
+const elementos = {
+    anioActual: document.getElementById('anio-actual'),
+    selectCajones: document.getElementById('cliente-cajon'),
+    formCliente: document.getElementById('cliente-form'),
+    mensajeCliente: document.getElementById('cliente-mensaje'),
+    formAdmin: document.getElementById('admin-login-form'),
+    errorAdmin: document.getElementById('admin-login-error'),
+    panelAdmin: document.getElementById('admin-panel'),
+    bienvenida: document.querySelector('#admin-panel .bienvenida'),
+    tablaStock: document.querySelector('#tabla-stock tbody'),
+    tablaPrecios: document.querySelector('#tabla-precios tbody'),
+    tablaPedidos: document.querySelector('#tabla-pedidos tbody'),
+    listaEntregas: document.getElementById('lista-entregas'),
+    listaLogins: document.getElementById('lista-logins'),
+    botonSalir: document.getElementById('admin-logout')
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    inicializarDatos();
+    elementos.anioActual.textContent = new Date().getFullYear();
+    poblarSelectCajones();
+    vincularEventos();
+});
+
+function inicializarDatos() {
+    if (!localStorage.getItem('pedidos')) {
+        localStorage.setItem('pedidos', JSON.stringify([]));
+    }
+    if (!localStorage.getItem('stock')) {
+        const stockInicial = CAJONES.reduce((acc, cajon) => {
+            acc[cajon.id] = 0;
+            return acc;
+        }, {});
+        localStorage.setItem('stock', JSON.stringify(stockInicial));
+    }
+    if (!localStorage.getItem('precios')) {
+        const preciosIniciales = CAJONES.reduce((acc, cajon) => {
+            acc[cajon.id] = 0;
+            return acc;
+        }, {});
+        localStorage.setItem('precios', JSON.stringify(preciosIniciales));
+    }
+    if (!localStorage.getItem('loginsAdmin')) {
+        localStorage.setItem('loginsAdmin', JSON.stringify([]));
+    }
+    if (!localStorage.getItem('entregas')) {
+        localStorage.setItem('entregas', JSON.stringify([]));
+    }
+}
+
+function poblarSelectCajones() {
+    elementos.selectCajones.innerHTML = '';
+    CAJONES.forEach(cajon => {
+        const option = document.createElement('option');
+        option.value = cajon.id;
+        option.textContent = cajon.nombre;
+        elementos.selectCajones.append(option);
+    });
+}
+
+function vincularEventos() {
+    elementos.formCliente.addEventListener('submit', manejarPedidoCliente);
+    elementos.formAdmin.addEventListener('submit', manejarLoginAdmin);
+    elementos.botonSalir.addEventListener('click', cerrarSesionAdmin);
+}
+
+function manejarPedidoCliente(evento) {
+    evento.preventDefault();
+    const cliente = document.getElementById('cliente-nombre').value.trim();
+    const direccion = document.getElementById('cliente-direccion').value.trim();
+    const cajonId = elementos.selectCajones.value;
+    const cantidad = parseInt(document.getElementById('cliente-cantidad').value, 10);
+
+    if (!cliente || !direccion || !cajonId || Number.isNaN(cantidad) || cantidad <= 0) {
+        mostrarMensajeCliente('Por favor complete todos los campos correctamente.', 'error');
+        return;
+    }
+
+    const nuevoPedido = {
+        id: crypto.randomUUID ? crypto.randomUUID() : `pedido-${Date.now()}`,
+        fecha: new Date().toISOString(),
+        cliente,
+        direccion,
+        cajonId,
+        cantidad,
+        estado: 'Pendiente'
+    };
+
+    const pedidos = obtenerPedidos();
+    pedidos.push(nuevoPedido);
+    guardarPedidos(pedidos);
+
+    elementos.formCliente.reset();
+    mostrarMensajeCliente('¡Pedido enviado correctamente! Nuestro equipo se comunicará para coordinar la entrega.', 'success');
+
+    if (adminActivo) {
+        renderizarPedidos();
+    }
+}
+
+function mostrarMensajeCliente(mensaje, tipo) {
+    elementos.mensajeCliente.textContent = mensaje;
+    elementos.mensajeCliente.className = tipo;
+}
+
+function manejarLoginAdmin(evento) {
+    evento.preventDefault();
+    const alias = document.getElementById('admin-alias').value.trim();
+    const usuario = document.getElementById('admin-usuario').value.trim();
+    const password = document.getElementById('admin-password').value;
+
+    const credencialValida = ADMINISTRADORES.some(admin => admin.usuario === usuario && admin.password === password);
+
+    if (!credencialValida) {
+        elementos.errorAdmin.textContent = 'Usuario o contraseña incorrectos.';
+        return;
+    }
+
+    adminActivo = { alias, usuario };
+    elementos.errorAdmin.textContent = '';
+    elementos.panelAdmin.hidden = false;
+    elementos.bienvenida.textContent = `Bienvenido/a ${alias}. Desde aquí puede gestionar stock, precios y entregas.`;
+
+    registrarLoginAdmin(alias, usuario);
+    renderizarTodo();
+    elementos.formAdmin.reset();
+}
+
+function cerrarSesionAdmin() {
+    adminActivo = null;
+    elementos.panelAdmin.hidden = true;
+}
+
+function renderizarTodo() {
+    renderizarStock();
+    renderizarPrecios();
+    renderizarPedidos();
+    renderizarEntregas();
+    renderizarLogins();
+}
+
+function renderizarStock() {
+    const stock = obtenerStock();
+    elementos.tablaStock.innerHTML = '';
+    CAJONES.forEach(cajon => {
+        const fila = document.createElement('tr');
+        const celdaNombre = document.createElement('td');
+        celdaNombre.textContent = cajon.nombre;
+
+        const celdaValor = document.createElement('td');
+        celdaValor.textContent = stock[cajon.id] ?? 0;
+
+        const celdaAccion = document.createElement('td');
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.min = '0';
+        input.step = '1';
+        input.value = stock[cajon.id] ?? 0;
+        input.ariaLabel = `Actualizar stock de ${cajon.nombre}`;
+
+        const boton = document.createElement('button');
+        boton.textContent = 'Guardar';
+        boton.addEventListener('click', () => {
+            const nuevoValor = parseInt(input.value, 10);
+            if (Number.isNaN(nuevoValor) || nuevoValor < 0) {
+                alert('Ingrese un número válido para el stock.');
+                return;
+            }
+            stock[cajon.id] = nuevoValor;
+            guardarStock(stock);
+            renderizarStock();
+        });
+
+        celdaAccion.append(input, boton);
+        fila.append(celdaNombre, celdaValor, celdaAccion);
+        elementos.tablaStock.append(fila);
+    });
+}
+
+function renderizarPrecios() {
+    const precios = obtenerPrecios();
+    elementos.tablaPrecios.innerHTML = '';
+    CAJONES.forEach(cajon => {
+        const fila = document.createElement('tr');
+        const celdaNombre = document.createElement('td');
+        celdaNombre.textContent = cajon.nombre;
+
+        const celdaValor = document.createElement('td');
+        celdaValor.textContent = formatearMoneda(precios[cajon.id] ?? 0);
+
+        const celdaAccion = document.createElement('td');
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.min = '0';
+        input.step = '0.01';
+        input.value = precios[cajon.id] ?? 0;
+        input.ariaLabel = `Actualizar precio de ${cajon.nombre}`;
+
+        const boton = document.createElement('button');
+        boton.textContent = 'Guardar';
+        boton.addEventListener('click', () => {
+            const nuevoValor = Number(input.value);
+            if (Number.isNaN(nuevoValor) || nuevoValor < 0) {
+                alert('Ingrese un valor numérico válido.');
+                return;
+            }
+            precios[cajon.id] = Number(nuevoValor.toFixed(2));
+            guardarPrecios(precios);
+            renderizarPrecios();
+        });
+
+        celdaAccion.append(input, boton);
+        fila.append(celdaNombre, celdaValor, celdaAccion);
+        elementos.tablaPrecios.append(fila);
+    });
+}
+
+function renderizarPedidos() {
+    const pedidos = obtenerPedidos();
+    elementos.tablaPedidos.innerHTML = '';
+
+    if (pedidos.length === 0) {
+        const filaVacia = document.createElement('tr');
+        const celda = document.createElement('td');
+        celda.colSpan = 6;
+        celda.textContent = 'Todavía no hay pedidos registrados.';
+        filaVacia.append(celda);
+        elementos.tablaPedidos.append(filaVacia);
+        return;
+    }
+
+    pedidos.sort((a, b) => new Date(b.fecha) - new Date(a.fecha));
+
+    pedidos.forEach(pedido => {
+        const fila = document.createElement('tr');
+        const celdaFecha = document.createElement('td');
+        celdaFecha.textContent = formatearFechaHora(pedido.fecha);
+
+        const celdaCliente = document.createElement('td');
+        celdaCliente.innerHTML = `<strong>${pedido.cliente}</strong><br><small>${pedido.direccion}</small>`;
+
+        const celdaCajon = document.createElement('td');
+        celdaCajon.textContent = obtenerNombreCajon(pedido.cajonId);
+
+        const celdaCantidad = document.createElement('td');
+        celdaCantidad.textContent = pedido.cantidad;
+
+        const celdaEstado = document.createElement('td');
+        celdaEstado.textContent = pedido.estado === 'Entregado' && pedido.entrega
+            ? `Entregado (${pedido.entrega.cantidad} cajones)`
+            : pedido.estado;
+        celdaEstado.className = pedido.estado === 'Entregado' ? 'estado-entregado' : 'estado-pendiente';
+
+        const celdaAcciones = document.createElement('td');
+        if (pedido.estado !== 'Entregado') {
+            const botonEntregar = document.createElement('button');
+            botonEntregar.textContent = 'Marcar como entregado';
+            botonEntregar.addEventListener('click', () => marcarEntrega(pedido.id));
+            celdaAcciones.append(botonEntregar);
+        } else {
+            celdaAcciones.innerHTML = `<small>Entregado por ${pedido.entrega.admin} el ${formatearFechaHora(pedido.entrega.fecha)}</small>`;
+        }
+
+        fila.append(celdaFecha, celdaCliente, celdaCajon, celdaCantidad, celdaEstado, celdaAcciones);
+        elementos.tablaPedidos.append(fila);
+    });
+}
+
+function marcarEntrega(idPedido) {
+    if (!adminActivo) {
+        alert('Debe iniciar sesión como administrador para realizar esta acción.');
+        return;
+    }
+
+    const pedidos = obtenerPedidos();
+    const pedido = pedidos.find(p => p.id === idPedido);
+    if (!pedido) {
+        alert('No se encontró el pedido seleccionado.');
+        return;
+    }
+
+    const cantidadEntregada = prompt('¿Cuántos cajones se entregaron?', pedido.cantidad);
+    const cantidad = parseInt(cantidadEntregada, 10);
+    if (Number.isNaN(cantidad) || cantidad <= 0) {
+        alert('Ingrese una cantidad válida de cajones entregados.');
+        return;
+    }
+
+    const fechaEntrega = new Date().toISOString();
+    pedido.estado = 'Entregado';
+    pedido.entrega = {
+        cantidad,
+        fecha: fechaEntrega,
+        admin: adminActivo.alias
+    };
+
+    guardarPedidos(pedidos);
+    registrarEntrega({
+        pedidoId: pedido.id,
+        cliente: pedido.cliente,
+        cajon: obtenerNombreCajon(pedido.cajonId),
+        cantidadSolicitada: pedido.cantidad,
+        cantidadEntregada: cantidad,
+        fecha: fechaEntrega,
+        admin: adminActivo.alias
+    });
+
+    renderizarPedidos();
+    renderizarEntregas();
+}
+
+function registrarLoginAdmin(alias, usuario) {
+    const logins = obtenerLoginsAdmin();
+    logins.push({ alias, usuario, fecha: new Date().toISOString() });
+    localStorage.setItem('loginsAdmin', JSON.stringify(logins));
+}
+
+function renderizarLogins() {
+    const logins = obtenerLoginsAdmin().sort((a, b) => new Date(b.fecha) - new Date(a.fecha));
+    elementos.listaLogins.innerHTML = '';
+    if (logins.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = 'Aún no hay ingresos registrados.';
+        elementos.listaLogins.append(li);
+        return;
+    }
+
+    logins.forEach(login => {
+        const li = document.createElement('li');
+        li.innerHTML = `<strong>${login.alias}</strong> (${login.usuario})<br><small>${formatearFechaHora(login.fecha)}</small>`;
+        elementos.listaLogins.append(li);
+    });
+}
+
+function registrarEntrega(entrega) {
+    const entregas = obtenerEntregas();
+    entregas.push(entrega);
+    localStorage.setItem('entregas', JSON.stringify(entregas));
+}
+
+function renderizarEntregas() {
+    const entregas = obtenerEntregas().sort((a, b) => new Date(b.fecha) - new Date(a.fecha));
+    elementos.listaEntregas.innerHTML = '';
+
+    if (entregas.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = 'Aún no se registraron entregas.';
+        elementos.listaEntregas.append(li);
+        return;
+    }
+
+    entregas.forEach(entrega => {
+        const li = document.createElement('li');
+        li.innerHTML = `Entrega de <strong>${entrega.cantidadEntregada}</strong> cajones de ${entrega.cajon} para ${entrega.cliente}<br>` +
+            `<small>Solicitado: ${entrega.cantidadSolicitada} cajones · Marcado por ${entrega.admin} el ${formatearFechaHora(entrega.fecha)}</small>`;
+        elementos.listaEntregas.append(li);
+    });
+}
+
+function obtenerPedidos() {
+    return JSON.parse(localStorage.getItem('pedidos'));
+}
+
+function guardarPedidos(pedidos) {
+    localStorage.setItem('pedidos', JSON.stringify(pedidos));
+}
+
+function obtenerStock() {
+    return JSON.parse(localStorage.getItem('stock'));
+}
+
+function guardarStock(stock) {
+    localStorage.setItem('stock', JSON.stringify(stock));
+}
+
+function obtenerPrecios() {
+    return JSON.parse(localStorage.getItem('precios'));
+}
+
+function guardarPrecios(precios) {
+    localStorage.setItem('precios', JSON.stringify(precios));
+}
+
+function obtenerLoginsAdmin() {
+    return JSON.parse(localStorage.getItem('loginsAdmin'));
+}
+
+function obtenerEntregas() {
+    return JSON.parse(localStorage.getItem('entregas'));
+}
+
+function formatearFechaHora(fechaISO) {
+    const fecha = new Date(fechaISO);
+    return fecha.toLocaleString('es-AR', {
+        dateStyle: 'short',
+        timeStyle: 'short'
+    });
+}
+
+function obtenerNombreCajon(id) {
+    return CAJONES.find(cajon => cajon.id === id)?.nombre ?? 'Cajón desconocido';
+}
+
+function formatearMoneda(valor) {
+    return new Intl.NumberFormat('es-AR', {
+        style: 'currency',
+        currency: 'ARS',
+        minimumFractionDigits: 2
+    }).format(valor);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,223 @@
+:root {
+    --color-principal: #1a4d2e;
+    --color-acento: #d4af37;
+    --color-fondo: #f7f7f7;
+    --color-texto: #1f1f1f;
+    --sombra-suave: 0 4px 12px rgba(0, 0, 0, 0.1);
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--color-fondo);
+    color: var(--color-texto);
+    line-height: 1.6;
+}
+
+header {
+    background: var(--color-principal);
+    color: #fff;
+    padding: 2rem 1rem;
+    text-align: center;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+header h1 {
+    margin: 0 0 0.5rem;
+    font-size: 2.5rem;
+}
+
+.tagline {
+    margin: 0 0 1.5rem;
+    font-weight: 500;
+}
+
+nav {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+nav a {
+    color: #fff;
+    text-decoration: none;
+    padding: 0.75rem 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 999px;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+nav a:hover,
+nav a:focus {
+    background: #fff;
+    color: var(--color-principal);
+}
+
+main {
+    padding: 2rem 1rem 4rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.panel {
+    background: #fff;
+    border-radius: 1rem;
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: var(--sombra-suave);
+}
+
+h2, h3, h4 {
+    color: var(--color-principal);
+}
+
+form {
+    display: grid;
+    gap: 1rem;
+}
+
+label {
+    font-weight: 600;
+}
+
+input, select, button {
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid #dcdcdc;
+    font-size: 1rem;
+}
+
+input:focus,
+select:focus,
+button:focus {
+    outline: 2px solid var(--color-acento);
+    outline-offset: 2px;
+}
+
+button {
+    background: var(--color-principal);
+    color: #fff;
+    cursor: pointer;
+    border: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+    transform: translateY(-1px);
+    box-shadow: var(--sombra-suave);
+}
+
+button.secondary {
+    background: transparent;
+    color: var(--color-principal);
+    border: 1px solid var(--color-principal);
+}
+
+#cliente-mensaje,
+#admin-login-error {
+    min-height: 1.5rem;
+    font-weight: 600;
+}
+
+#cliente-mensaje.success {
+    color: #1b7d2c;
+}
+
+#cliente-mensaje.error,
+#admin-login-error {
+    color: #b11b1b;
+}
+
+.admin-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.admin-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.admin-grid article {
+    background: #fff;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    box-shadow: inset 0 0 0 1px #f0f0f0;
+    max-height: 450px;
+    overflow: auto;
+}
+
+.admin-grid article.historial {
+    grid-column: span 2;
+}
+
+.admin-grid table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.admin-grid th,
+.admin-grid td {
+    padding: 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+}
+
+.admin-grid td input {
+    width: 100%;
+}
+
+.estado-entregado {
+    color: #1b7d2c;
+    font-weight: 700;
+}
+
+.estado-pendiente {
+    color: #b11b1b;
+    font-weight: 700;
+}
+
+.historial ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.historial li {
+    margin-bottom: 0.75rem;
+    background: #f4f7f5;
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+}
+
+footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    background: #fff;
+    color: #666;
+}
+
+@media (max-width: 768px) {
+    header h1 {
+        font-size: 2rem;
+    }
+
+    nav a {
+        padding: 0.5rem 1rem;
+    }
+
+    .panel {
+        padding: 1.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- create a single-page site with dedicated sections for clientes y administradores
- allow clientes to registrar pedidos indicando local, dirección, cajón y cantidad
- enable administradores to iniciar sesión con credenciales fijas, gestionar stock y precios, revisar pedidos y registrar entregas con historial

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce19809f688332a02c7703639a51ad